### PR TITLE
buster: arm64: use mrvl-fw-image 3.2.2

### DIFF
--- a/REPO/buster/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
+++ b/REPO/buster/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
@@ -1,0 +1,1 @@
+../../stretch/packages/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb


### PR DESCRIPTION
Signed-off-by: Taras Chornyi <taras.chornyi@plvision.eu>