### PR TITLE
buster: arm64: Fix mrvl-fw-image path

### DIFF
--- a/REPO/buster/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
+++ b/REPO/buster/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
@@ -1,1 +1,0 @@
-../../stretch/packages/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb

--- a/REPO/buster/packages/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
+++ b/REPO/buster/packages/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb
@@ -1,0 +1,1 @@
+../../../stretch/packages/binary-arm64/mrvl-fw-image_3.2.2_arm64.deb


### PR DESCRIPTION
Fixed issue with arm64 packages path

Signed-off-by: Taras Chornyi <taras.chornyi@plvision.eu>