### PR TITLE
Adds: DENT-GNS3-Appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-
-### Firmware Packages & dentOS Tool Versions
 Packages for Mellanox and Marvell Firmware and specific versions of tools used to build dentOS
 
-- mstpd
-- ethtool 5.6.0
-- iproute2 5.6.0
-- lldpd 1.0.5
-- mft 4.14.0-105
-- realpath 8.26-3
-- frr 6.0.3
+mstpd
+ethtool 5.6.0
+iproute2 5.6.0
+lldpd 1.0.5
+mft 4.14.0-105
+realpath 8.26-3
+frr 6.0.3
 
----
 ### Dent GNS3 Appliance
 
 All necessary files for setting up the DENT GNS3 Appliance, including the disk image, XML configuration, and related artifacts can be found here: [DENT GNS3 Appliance](https://1drv.ms/f/c/b4d5fd54a1a7d444/EkTUp6FU_dUggLQdrwAAAAABU-4TzozwwGtsV7u5ib1Q0A?e=mEEETi)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
+
+### Firmware Packages & dentOS Tool Versions
 Packages for Mellanox and Marvell Firmware and specific versions of tools used to build dentOS
 
-mstpd
-ethtool 5.6.0
-iproute2 5.6.0
-lldpd 1.0.5
-mft 4.14.0-105
-realpath 8.26-3
-frr 6.0.3
+- mstpd
+- ethtool 5.6.0
+- iproute2 5.6.0
+- lldpd 1.0.5
+- mft 4.14.0-105
+- realpath 8.26-3
+- frr 6.0.3
+
+---
+### Dent GNS3 Appliance
+
+All necessary files for setting up the DENT GNS3 Appliance, including the disk image, XML configuration, and related artifacts can be found here: [DENT GNS3 Appliance](https://1drv.ms/f/c/b4d5fd54a1a7d444/EkTUp6FU_dUggLQdrwAAAAABU-4TzozwwGtsV7u5ib1Q0A?e=mEEETi)
+
+For information on how to set up the DENT GNS3 Appliance in GNS3 please view the [DENT DOCS](https://docs.dent.dev/Installation.html)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ frr 6.0.3
 
 ### Dent GNS3 Appliance
 
-All necessary files for setting up the DENT GNS3 Appliance, including the disk image, XML configuration, and related artifacts can be found here: [DENT GNS3 Appliance](https://1drv.ms/f/c/b4d5fd54a1a7d444/EkTUp6FU_dUggLQdrwAAAAABU-4TzozwwGtsV7u5ib1Q0A?e=mEEETi)
+All necessary files for setting up the DENT GNS3 Appliance, including the disk image, XML configuration, and related artifacts can be found here: [DENT GNS3 Appliance](https://repos.refinery.dev/service/rest/repository/browse/dent/releases/org/dent/3.2/)
 
 For information on how to set up the DENT GNS3 Appliance in GNS3 please view the [DENT DOCS](https://docs.dent.dev/Installation.html)


### PR DESCRIPTION
Adds a link to the files for setting up the DENT GNS3 Appliance to the ReadMe of the dent-artifacts repo. The files include the disk image, XML configuration, and related artifacts hosted using a view only link from OneDrive. Information on how to set up the GNS3 Appliance is also included.